### PR TITLE
Fix for issue #23 and relative file paths (#22)

### DIFF
--- a/controls.py
+++ b/controls.py
@@ -47,13 +47,11 @@ def setDef(bulb, index):
 
 # change the default behavior of the light bulb when turned on by switch to a preset index
 def setDefHard(bulb, index):
-    #hard on (with switch)
     data = '{"smartlife.iot.smartbulb.lightingservice":{"set_default_behavior":{"hard_on":{"mode":"customize_preset","index":' + str(index) + '}}}}'
     sockSend(bulb, data)
     
 # change the default behavior of the light bulb when turned on by software to a preset index
 def setDefSoft(bulb, index):
-    #soft on (with app or alexa)
     data = '{"smartlife.iot.smartbulb.lightingservice":{"set_default_behavior":{"soft_on":{"mode":"customize_preset","index":' + str(index) + '}}}}'
     sockSend(bulb, data)
 
@@ -92,12 +90,13 @@ def getStatus(bulb):
  
 # initialize the file for the dictionary of the devices and their IDs
 def initDev():
+    programDir = os.path.dirname(os.path.abspath(__file__))
     # call bash script to save network devices to file
-    subprocess.call("bash/devIP.sh")
+    subprocess.call(programDir + "/bash/devIP.sh")
 
     # open network list for reading
-    fin = open('/home/pi/Circadian-Lights/network.list', 'r')
-    fout = open('/home/pi/Circadian-Lights/devices.list', 'w+')
+    fin = open(programDir + '/network.list', 'r')
+    fout = open(programDir + '/devices.list', 'w+')
     text = fin.readlines()
     for line in text:
         if line[0:5] == "LB130":
@@ -107,4 +106,4 @@ def initDev():
                     fout.write(IP + "\n")
 
     # delete network.list file
-    os.remove('network.list')
+    os.remove(programDir + '/network.list')

--- a/getSunCron
+++ b/getSunCron
@@ -1,2 +1,2 @@
-0 0 * * * root /usr/bin/python /home/pi/Circadian-Lights/getSun.py
+0 0 * * * root /usr/bin/python /etc/cron.d/getSun.py
 

--- a/night.py
+++ b/night.py
@@ -5,16 +5,20 @@ import json
 import signal
 
 
+programDir = os.path.dirname(os.path.abspath(__file__))
+
 # load devices in from file
 def loadDev():
 
-    if os.path.exists("/home/pi/Circadian-Lights/devices.list"):
-        f = open("/home/pi/Circadian-Lights/devices.list", "r")
+    if os.path.exists(programDir + "/devices.list"):
+        f = open(programDir + "/devices.list", "r")
         bulbs = f.read().splitlines()
+        f.close()
     else:
         controls.initDev()
-        f = open("/home/pi/Circadian-Lights/devices.list", "r")
+        f = open(programDir + "/devices.list", "r")
         bulbs = f.read().splitlines()
+        f.close()
 
     print("Devices loaded successfully")
     return bulbs
@@ -22,15 +26,17 @@ def loadDev():
 
 # load the relevant values in from the file
 def loadStates():
-    if os.path.exists("/home/pi/Circadian-Lights/values.target"):
-        f = open("/home/pi/Circadian-Lights/values.target", "r")
+    if os.path.exists(programDir + "/values.target"):
+        f = open(programDir + "/values.target", "r")
         states = json.loads(f.read())
+        f.close()
     else:
         states = {"Night":{"Temp":2700,"Brightness":1},\
                   "Evening":{"Temp":2875,"Brightness":30},\
                   "Midday":{"Temp":3800,"Brightness":80}}
-        f = open("/home/pi/Circadian-Lights/values.target", "w+")
+        f = open(programDir + "/values.target", "w+")
         f.write(json.dumps(states))
+        f.close()
 
     print("States loaded successfully")
     return states
@@ -39,8 +45,9 @@ def loadStates():
 def killLast():
     # check last.pid
     print("Checking for any hanging scripts")
-    f = open("/home/pi/Circadian-Lights/last.pid", "r")
+    f = open(programDir + "/last.pid", "r")
     pid = int(f.readline())
+    f.close()
     
     # If script still running
     if pid >= 0:
@@ -57,12 +64,14 @@ def killLast():
 
 def writePID(hanging):
     if hanging == True:
-        f = open("/home/pi/Circadian-Lights/last.pid", "w+")
+        f = open(programDir + "/last.pid", "w+")
         f.write(str(os.getpid()))
+        f.close()
         print("Wrote PID to file")
     else:
-        f = open("/home/pi/Circadian-Lights/last.pid", "w+")
+        f = open(programDir + "/last.pid", "w+")
         f.write(str(-1))
+        f.close()
         print("Wrote dummy PID to file")
 
 
@@ -81,6 +90,9 @@ def changeLight(interval, currTemp, currBrightness, targetTemp, targetBrightness
             print("waiting...")
             start = time.time()
             status = controls.getStatus(bulbs[0])
+            if status != "error":
+                currTemp = status[1]
+                currBrightness = status[2]
             end = time.time()
             if count < interval:
                 count+=int(end-start)
@@ -94,6 +106,9 @@ def changeLight(interval, currTemp, currBrightness, targetTemp, targetBrightness
                 print("waiting...")
                 start = time.time()
                 status = controls.getStatus(bulbs[0])
+                if status != "error":
+                    currTemp = status[1]
+                    currBrightness = status[2]
                 end = time.time()
                 count+=int(end-start)
             # if light comes on, change it
@@ -125,7 +140,7 @@ def changeLight(interval, currTemp, currBrightness, targetTemp, targetBrightness
     # if light responsive and on
     if status[0] == 1:
         print("light responsive and on")
-        
+
         # I split this into two loops to have the actual changing of each light closer together
         start = time.time()
         # Manual override detection. Only change light if no manual override detected

--- a/sunset.py
+++ b/sunset.py
@@ -5,16 +5,20 @@ import json
 import signal
 
 
+programDir = os.path.dirname(os.path.abspath(__file__))
+
 # load devices in from file
 def loadDev():
 
-    if os.path.exists("/home/pi/Circadian-Lights/devices.list"):
-        f = open("/home/pi/Circadian-Lights/devices.list", "r")
+    if os.path.exists(programDir + "/devices.list"):
+        f = open(programDir + "/devices.list", "r")
         bulbs = f.read().splitlines()
+        f.close()
     else:
         controls.initDev()
-        f = open("/home/pi/Circadian-Lights/devices.list", "r")
+        f = open(programDir + "/devices.list", "r")
         bulbs = f.read().splitlines()
+        f.close()
 
     print("Devices loaded successfully")
     return bulbs
@@ -22,15 +26,17 @@ def loadDev():
 
 # load the relevant values in from the file
 def loadStates():
-    if os.path.exists("/home/pi/Circadian-Lights/values.target"):
-        f = open("/home/pi/Circadian-Lights/values.target", "r")
+    if os.path.exists(programDir + "/values.target"):
+        f = open(programDir + "/values.target", "r")
         states = json.loads(f.read())
+        f.close()
     else:
         states = {"Night":{"Temp":2700,"Brightness":1},\
                   "Evening":{"Temp":2875,"Brightness":30},\
                   "Midday":{"Temp":3800,"Brightness":80}}
-        f = open("/home/pi/Circadian-Lights/values.target", "w+")
+        f = open(programDir + "/values.target", "w+")
         f.write(json.dumps(states))
+        f.close()
 
     print("States loaded successfully")
     return states
@@ -39,8 +45,9 @@ def loadStates():
 def killLast():
     # check last.pid
     print("Checking for any hanging scripts")
-    f = open("/home/pi/Circadian-Lights/last.pid", "r")
+    f = open(programDir + "/last.pid", "r")
     pid = int(f.readline())
+    f.close()
     
     # If script still running
     if pid >= 0:
@@ -57,12 +64,14 @@ def killLast():
 
 def writePID(hanging):
     if hanging == True:
-        f = open("/home/pi/Circadian-Lights/last.pid", "w+")
+        f = open(programDir + "/last.pid", "w+")
         f.write(str(os.getpid()))
+        f.close()
         print("Wrote PID to file")
     else:
-        f = open("/home/pi/Circadian-Lights/last.pid", "w+")
+        f = open(programDir + "/last.pid", "w+")
         f.write(str(-1))
+        f.close()
         print("Wrote dummy PID to file")
 
 
@@ -81,6 +90,9 @@ def changeLight(interval, currTemp, currBrightness, targetTemp, targetBrightness
             print("waiting...")
             start = time.time()
             status = controls.getStatus(bulbs[0])
+            if status != "error":
+                currTemp = status[1]
+                currBrightness = status[2]
             end = time.time()
             if count < interval:
                 count+=int(end-start)
@@ -94,6 +106,9 @@ def changeLight(interval, currTemp, currBrightness, targetTemp, targetBrightness
                 print("waiting...")
                 start = time.time()
                 status = controls.getStatus(bulbs[0])
+                if status != "error":
+                    currTemp = status[1]
+                    currBrightness = status[2]
                 end = time.time()
                 count+=int(end-start)
             # if light comes on, change it


### PR DESCRIPTION
This commit resolves #23 and resolves #22. The changes in the code allow the program to be much more portable.

I changed all the absolute file paths to relative file paths. I also made changes to getSun.py and getSunCron. The former of which will now also reside in the /etc/cron.d directory. getSun.py also locates the sunrise.py and sunset.py scripts prior to creating the cron file entries for those scripts.

This allows the user to change the installation location without affecting the program too much. (The scripts won't run until the next getSun runs). Further work should be done to increase the portability here.

As far as issue #23, this commit also fixes the issue with the bulbs not changing after shutoff at the switch for an extended period of time.

All code was tested and working in a controlled environment and will continue to be monitored over the next couple of days in the deployed environment.